### PR TITLE
Disable Timer on World Change

### DIFF
--- a/FlightControl/src/main/java/org/spazzinq/flightcontrol/EventListener.java
+++ b/FlightControl/src/main/java/org/spazzinq/flightcontrol/EventListener.java
@@ -93,14 +93,29 @@ final class EventListener implements org.bukkit.event.Listener {
     }
 
     /**
+    * Checks a player's flight status when they world change, and disables the trail if necessary.
+    */
+    @EventHandler
+    public void onPlayerChangedWorldEvent(PlayerChangedWorldEvent e) {
+        Player p = e.getPlayer();
+        pl.getFlightManager().check(p);
+        if (!p.getAllowFlight()) {
+            pl.getTrailManager().disableTrail(p);
+        }
+
+    }
+
+    /**
      * Checks a player's flight status when they teleport, and disables the trail if necessary.
      */
-    @EventHandler private void onTP(PlayerTeleportEvent e) {
+    @EventHandler
+    private void onTP(PlayerTeleportEvent e) {
         // Prevent calling on login because another handler takes care of that
         if (e.getCause() != PlayerTeleportEvent.TeleportCause.UNKNOWN) {
             Player p = e.getPlayer();
 
-            pl.getFlightManager().check(p);
+            if (e.getFrom().getWorld().equals(e.getTo().getWorld()))
+                pl.getFlightManager().check(p);
 
             // Fixes a bug where particles remain when not supposed so
             if (!p.getAllowFlight()) {

--- a/FlightControl/src/main/java/org/spazzinq/flightcontrol/EventListener.java
+++ b/FlightControl/src/main/java/org/spazzinq/flightcontrol/EventListener.java
@@ -93,29 +93,14 @@ final class EventListener implements org.bukkit.event.Listener {
     }
 
     /**
-    * Checks a player's flight status when they world change, and disables the trail if necessary.
-    */
-    @EventHandler
-    public void onPlayerChangedWorldEvent(PlayerChangedWorldEvent e) {
-        Player p = e.getPlayer();
-        pl.getFlightManager().check(p);
-        if (!p.getAllowFlight()) {
-            pl.getTrailManager().disableTrail(p);
-        }
-
-    }
-
-    /**
      * Checks a player's flight status when they teleport, and disables the trail if necessary.
      */
-    @EventHandler
-    private void onTP(PlayerTeleportEvent e) {
+    @EventHandler private void onTP(PlayerTeleportEvent e) {
         // Prevent calling on login because another handler takes care of that
         if (e.getCause() != PlayerTeleportEvent.TeleportCause.UNKNOWN) {
             Player p = e.getPlayer();
 
-            if (e.getFrom().getWorld().equals(e.getTo().getWorld()))
-                pl.getFlightManager().check(p);
+            pl.getFlightManager().check(p);
 
             // Fixes a bug where particles remain when not supposed so
             if (!p.getAllowFlight()) {

--- a/FlightControl/src/main/java/org/spazzinq/flightcontrol/EventListener.java
+++ b/FlightControl/src/main/java/org/spazzinq/flightcontrol/EventListener.java
@@ -93,16 +93,12 @@ final class EventListener implements org.bukkit.event.Listener {
     }
 
     /**
-    * Checks a player's flight status when they world change, and disables the trail if necessary.
-    */
+     * Checks a player's flight status when they world change, and disables the trail if necessary.
+     */
     @EventHandler
     public void onPlayerChangedWorldEvent(PlayerChangedWorldEvent e) {
         Player p = e.getPlayer();
-        pl.getFlightManager().check(p);
-        if (!p.getAllowFlight()) {
-            pl.getTrailManager().disableTrail(p);
-        }
-
+        checkPlayer(p);
     }
 
     /**
@@ -115,12 +111,15 @@ final class EventListener implements org.bukkit.event.Listener {
             Player p = e.getPlayer();
 
             if (e.getFrom().getWorld().equals(e.getTo().getWorld()))
-                pl.getFlightManager().check(p);
+                checkPlayer(p);
+        }
+    }
 
-            // Fixes a bug where particles remain when not supposed so
-            if (!p.getAllowFlight()) {
-                pl.getTrailManager().disableTrail(p);
-            }
+    private void checkPlayer(Player p) {
+        pl.getFlightManager().check(p);
+        // Fixes a bug where particles remain when not supposed so
+        if (!p.getAllowFlight()) {
+            pl.getTrailManager().disableTrail(p);
         }
     }
 

--- a/FlightControl/src/main/java/org/spazzinq/flightcontrol/manager/FlightManager.java
+++ b/FlightControl/src/main/java/org/spazzinq/flightcontrol/manager/FlightManager.java
@@ -69,22 +69,23 @@ public class FlightManager {
             boolean disable = !disableChecks.isEmpty();
             Cause enableCause = enable ? enableChecks.iterator().next().getCause() : null;
             Cause disableCause = disable ? disableChecks.iterator().next().getCause() : null;
-
             if (p.getAllowFlight()) {
                 // If override or not enabled
                 if (disable || !enable) {
                     disableFlight(p, disableCause,false);
                 }
             // If all clear to enable
+
             } else if (enable && !disable) {
                 // If directly enabled or auto-enable is enabled
+
                 if (isCommand || (pl.getConfManager().isAutoEnable() && !disabledByPlayer.contains(p))) {
                     enableFlight(p, enableCause, isCommand);
                 } else {
                     canEnable(p, enableCause);
                 }
             // If denied
-            } else if (isCommand || alreadyCanMsg.contains(p)) {
+            } else if (isCommand || (alreadyCanMsg.contains(p) && !disabledByPlayer.contains(p))) {
                 cannotEnable(p, disableCause);
             }
         // If bypassing checks
@@ -124,6 +125,9 @@ public class FlightManager {
         APIManager.getInstance().callEvent(e);
 
         if (!e.isCancelled()) {
+            pl.getPlayerManager().getFlightPlayer(p).getTempflyTimer().pause();
+            p.setAllowFlight(false);
+            p.setFlying(false);
             alreadyCanMsg.remove(p);
             Sound.play(p, e.getSound());
             msg(p, e.getMessage(), e.isByActionbar());
@@ -140,6 +144,7 @@ public class FlightManager {
             if (isCommand) {
                 disabledByPlayer.remove(p);
             }
+            alreadyCanMsg.add(p);
             p.setAllowFlight(true);
             // Ignore if not double-tapped
             if (!Sound.playEveryEnable) {
@@ -154,16 +159,14 @@ public class FlightManager {
                 Sound.disableSound, pl.getLangManager().useActionBar(), isCommand);
 
         APIManager.getInstance().callEvent(e);
-
         if (!e.isCancelled()) {
+
             pl.getPlayerManager().getFlightPlayer(p).getTempflyTimer().pause();
 
             if (isCommand) {
                 disabledByPlayer.add(p);
-                alreadyCanMsg.add(p);
-            } else {
-                alreadyCanMsg.remove(p);
             }
+            alreadyCanMsg.remove(p);
 
             if (pl.getConfManager().isCancelFall() && p.isFlying()) {
                 noFallDmg.add(p);


### PR DESCRIPTION
Hi of course you can test, the concern was that the time continued when we were in a world without fly and being on the ground.
It is therefore necessary when people can not fly deactivate the fly and pause the timer.